### PR TITLE
DEVXP - Fix libyear calculation for libyears_behind field

### DIFF
--- a/libyear/export_format/json.py
+++ b/libyear/export_format/json.py
@@ -3,6 +3,7 @@ from typing import TextIO, List
 from pydantic import BaseModel
 
 from libyear.export_format.export_format import Item
+from libyear.utils import calculate_libyear
 
 
 class Dependency(BaseModel):
@@ -14,7 +15,7 @@ class Dependency(BaseModel):
 
 class JsonOutput(BaseModel):
     dependencies: List[Dependency] = []
-    libyears_behind: int = 0
+    libyears_behind: str = ''
 
 
 class JSONFormatter:
@@ -36,7 +37,7 @@ class JSONFormatter:
         )
 
     def end(self, days: int):
-        self.json_output.libyears_behind = days
+        self.json_output.libyears_behind = calculate_libyear(days=days)
 
         if self.sort:
             self.json_output.dependencies.sort(key= lambda dep : (dep.libyear, dep.name))

--- a/tests/test_libyear.py
+++ b/tests/test_libyear.py
@@ -347,6 +347,6 @@ def test_libyear_main_output_with_json(capsys):
                 'libyear': '7.71',
                 },
             ],
-        'libyears_behind': 61012
+        'libyears_behind': '167.16'
     }
 


### PR DESCRIPTION
When introducing the JSON output format, I forgot to call the libyear calculation used for ASCII.